### PR TITLE
refactor: Update repository references from 'nexkit-vscode' to 'nexus-nexkit-vscode'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ This project adheres to professional standards of collaboration. Please be respe
 1. **Clone the repository**
 
    ```bash
-   git clone https://github.com/NexusInnovation/nexkit-vscode.git
+   git clone https://github.com/NexusInnovation/nexus-nexkit-vscode.git
    cd nexkit-vscode
    ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Nexkit VS Code Extension
 
-[![CI/CD Pipeline](https://github.com/NexusInnovation/nexkit-vscode/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/NexusInnovation/nexkit-vscode/actions/workflows/ci-cd.yml)
-[![Latest Release](https://img.shields.io/github/v/release/NexusInnovation/nexkit-vscode)](https://github.com/NexusInnovation/nexkit-vscode/releases/latest)
+[![CI/CD Pipeline](https://github.com/NexusInnovation/nexus-nexkit-vscode/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/NexusInnovation/nexus-nexkit-vscode/actions/workflows/ci-cd.yml)
+[![Latest Release](https://img.shields.io/github/v/release/NexusInnovation/nexus-nexkit-vscode)](https://github.com/NexusInnovation/nexus-nexkit-vscode/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A VS Code extension that migrates the functionality of the Nexkit CLI tool to provide Copilot-only spec-driven development workflows.
@@ -23,9 +23,9 @@ This extension provides the following commands (accessible via Command Palette o
 
 1. **Download the latest VSIX package**
 
-   - Visit the [latest release](https://github.com/NexusInnovation/nexkit-vscode/releases/latest)
+   - Visit the [latest release](https://github.com/NexusInnovation/nexus-nexkit-vscode/releases/latest)
    - Download `nexkit-vscode.vsix`
-   - Or use this direct link: [Download Latest VSIX](https://github.com/NexusInnovation/nexkit-vscode/releases/latest/download/nexkit-vscode.vsix)
+   - Or use this direct link: [Download Latest VSIX](https://github.com/NexusInnovation/nexus-nexkit-vscode/releases/latest/download/nexkit-vscode.vsix)
 
 2. **Install in VS Code**
 
@@ -96,7 +96,7 @@ Templates are updated when you install a new version of the extension - no separ
 
 ## Known Issues
 
-See [GitHub Issues](https://github.com/NexusInnovation/nexkit-vscode/issues) for known issues and bug reports.
+See [GitHub Issues](https://github.com/NexusInnovation/nexus-nexkit-vscode/issues) for known issues and bug reports.
 
 ## Release Notes
 
@@ -104,7 +104,7 @@ See [CHANGELOG.md](CHANGELOG.md) for detailed release notes.
 
 ### Latest Release
 
-Check the [latest release](https://github.com/NexusInnovation/nexkit-vscode/releases/latest) for the most recent version and changes.
+Check the [latest release](https://github.com/NexusInnovation/nexus-nexkit-vscode/releases/latest) for the most recent version and changes.
 
 ---
 
@@ -115,7 +115,7 @@ To develop this extension:
 1. **Clone the repository**
 
    ```bash
-   git clone https://github.com/NexusInnovation/nexkit-vscode.git
+   git clone https://github.com/NexusInnovation/nexus-nexkit-vscode.git
    cd nexkit-vscode
    ```
 
@@ -198,10 +198,10 @@ MIT License - See [LICENSE](LICENSE) file for details.
 
 ## Support
 
-- **Issues**: [GitHub Issues](https://github.com/NexusInnovation/nexkit-vscode/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/NexusInnovation/nexkit-vscode/discussions)
+- **Issues**: [GitHub Issues](https://github.com/NexusInnovation/nexus-nexkit-vscode/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/NexusInnovation/nexus-nexkit-vscode/discussions)
 
 ---
 
 **Maintained by**: Nexus Innovation  
-**Repository**: [github.com/NexusInnovation/nexkit-vscode](https://github.com/NexusInnovation/nexkit-vscode)
+**Repository**: [github.com/NexusInnovation/nexus-nexkit-vscode](https://github.com/NexusInnovation/nexus-nexkit-vscode)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nexusinno/nexkit-vscode.git"
+    "url": "https://github.com/NexusInnovation/nexus-nexkit-vscode.git"
   },
   "engines": {
     "vscode": "^1.105.0"

--- a/scripts/test-github-download.js
+++ b/scripts/test-github-download.js
@@ -5,7 +5,7 @@
  * Run this outside of VS Code extension environment
  */
 
-const testUrl = 'https://github.com/NexusInnovation/nexkit-vscode/releases/download/v0.3.7/nexkit-vscode.vsix';
+const testUrl = 'https://github.com/NexusInnovation/nexus-nexkit-vscode/releases/download/v0.3.7/nexkit-vscode.vsix';
 
 async function testGitHubDownload() {
     console.log('🔧 Testing GitHub private repository download...');

--- a/src/extensionUpdateManager.ts
+++ b/src/extensionUpdateManager.ts
@@ -157,7 +157,7 @@ export class ExtensionUpdateManager {
 
     if (result === "View Release Notes") {
       // Open GitHub release page
-      const releaseUrl = `https://github.com/NexusInnovation/nexkit/releases/tag/${updateInfo.releaseInfo.tagName}`;
+      const releaseUrl = `https://github.com/NexusInnovation/nexus-nexkit-vscode/releases/tag/${updateInfo.releaseInfo.tagName}`;
       await vscode.env.openExternal(vscode.Uri.parse(releaseUrl));
       return;
     }

--- a/src/githubReleaseService.ts
+++ b/src/githubReleaseService.ts
@@ -12,7 +12,7 @@ export interface ReleaseInfo {
 
 export class GitHubReleaseService {
   private static readonly REPO_OWNER = "NexusInnovation";
-  private static readonly REPO_NAME = "nexkit-vscode";
+  private static readonly REPO_NAME = "nexus-nexkit-vscode";
   private static readonly BASE_URL = "https://api.github.com";
   private static readonly GITHUB_AUTH_PROVIDER_ID = "github";
   private static readonly REQUIRED_SCOPES = ["repo"];

--- a/src/test/downloadDiagnostic.ts
+++ b/src/test/downloadDiagnostic.ts
@@ -1,110 +1,114 @@
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 
 /**
  * Simple diagnostic script to test GitHub release downloads
  */
 async function testGitHubDownload() {
-    const testUrl = 'https://github.com/NexusInnovation/nexkit-vscode/releases/download/v0.3.7/nexkit-vscode.vsix';
+  const testUrl =
+    "https://github.com/NexusInnovation/nexus-nexkit-vscode/releases/download/v0.3.7/nexkit-vscode.vsix";
 
-    try {
-        // Get authentication session
-        console.log('Getting GitHub authentication session...');
-        const session = await vscode.authentication.getSession(
-            'github',
-            ['repo'],
-            { createIfNone: true, silent: false }
-        );
+  try {
+    // Get authentication session
+    console.log("Getting GitHub authentication session...");
+    const session = await vscode.authentication.getSession("github", ["repo"], {
+      createIfNone: true,
+      silent: false,
+    });
 
-        if (!session) {
-            console.log('❌ No GitHub session available');
-            return;
+    if (!session) {
+      console.log("❌ No GitHub session available");
+      return;
+    }
+
+    console.log("✅ GitHub session obtained");
+
+    const headers = {
+      "User-Agent": "Nexkit-VSCode-Extension",
+      Accept: "application/octet-stream",
+      Authorization: `Bearer ${session.accessToken}`,
+    };
+
+    // Test 1: Direct fetch with manual redirect handling
+    console.log("\n🔍 Test 1: Direct fetch with manual redirect handling");
+    const response1 = await fetch(testUrl, {
+      headers,
+      redirect: "manual",
+    });
+
+    console.log(`Status: ${response1.status}`);
+    console.log(`Status Text: ${response1.statusText}`);
+
+    if (response1.status >= 300 && response1.status < 400) {
+      const location = response1.headers.get("location");
+      console.log(`🔄 Redirect to: ${location}`);
+
+      if (location) {
+        console.log("\n🔍 Test 2: Following redirect with Auth header");
+        const response2 = await fetch(location, {
+          headers,
+          redirect: "manual",
+        });
+
+        console.log(`Redirect Status: ${response2.status}`);
+        console.log(`Redirect Status Text: ${response2.statusText}`);
+
+        if (response2.ok) {
+          const contentLength = response2.headers.get("content-length");
+          console.log(`✅ Success! Content length: ${contentLength}`);
         }
 
-        console.log('✅ GitHub session obtained');
-
-        const headers = {
-            'User-Agent': 'Nexkit-VSCode-Extension',
-            'Accept': 'application/octet-stream',
-            'Authorization': `Bearer ${session.accessToken}`
+        console.log("\n🔍 Test 3: Following redirect WITHOUT Auth header");
+        const headersNoAuth = {
+          "User-Agent": "Nexkit-VSCode-Extension",
+          Accept: "application/octet-stream",
         };
 
-        // Test 1: Direct fetch with manual redirect handling
-        console.log('\n🔍 Test 1: Direct fetch with manual redirect handling');
-        const response1 = await fetch(testUrl, {
-            headers,
-            redirect: 'manual'
+        const response3 = await fetch(location, {
+          headers: headersNoAuth,
+          redirect: "manual",
         });
 
-        console.log(`Status: ${response1.status}`);
-        console.log(`Status Text: ${response1.statusText}`);
+        console.log(`No-Auth Status: ${response3.status}`);
+        console.log(`No-Auth Status Text: ${response3.statusText}`);
 
-        if (response1.status >= 300 && response1.status < 400) {
-            const location = response1.headers.get('location');
-            console.log(`🔄 Redirect to: ${location}`);
-
-            if (location) {
-                console.log('\n🔍 Test 2: Following redirect with Auth header');
-                const response2 = await fetch(location, {
-                    headers,
-                    redirect: 'manual'
-                });
-
-                console.log(`Redirect Status: ${response2.status}`);
-                console.log(`Redirect Status Text: ${response2.statusText}`);
-
-                if (response2.ok) {
-                    const contentLength = response2.headers.get('content-length');
-                    console.log(`✅ Success! Content length: ${contentLength}`);
-                }
-
-                console.log('\n🔍 Test 3: Following redirect WITHOUT Auth header');
-                const headersNoAuth = {
-                    'User-Agent': 'Nexkit-VSCode-Extension',
-                    'Accept': 'application/octet-stream'
-                };
-
-                const response3 = await fetch(location, {
-                    headers: headersNoAuth,
-                    redirect: 'manual'
-                });
-
-                console.log(`No-Auth Status: ${response3.status}`);
-                console.log(`No-Auth Status Text: ${response3.statusText}`);
-
-                if (response3.ok) {
-                    const contentLength = response3.headers.get('content-length');
-                    console.log(`✅ Success without auth! Content length: ${contentLength}`);
-                }
-            }
+        if (response3.ok) {
+          const contentLength = response3.headers.get("content-length");
+          console.log(
+            `✅ Success without auth! Content length: ${contentLength}`
+          );
         }
-
-        // Test 4: Let fetch handle redirects automatically
-        console.log('\n🔍 Test 4: Automatic redirect handling');
-        const response4 = await fetch(testUrl, {
-            headers,
-            redirect: 'follow'
-        });
-
-        console.log(`Auto-redirect Status: ${response4.status}`);
-        console.log(`Auto-redirect Final URL: ${response4.url}`);
-
-        if (response4.ok) {
-            const contentLength = response4.headers.get('content-length');
-            console.log(`✅ Auto-redirect Success! Content length: ${contentLength}`);
-        }
-
-    } catch (error) {
-        console.error('❌ Test failed:', error);
+      }
     }
+
+    // Test 4: Let fetch handle redirects automatically
+    console.log("\n🔍 Test 4: Automatic redirect handling");
+    const response4 = await fetch(testUrl, {
+      headers,
+      redirect: "follow",
+    });
+
+    console.log(`Auto-redirect Status: ${response4.status}`);
+    console.log(`Auto-redirect Final URL: ${response4.url}`);
+
+    if (response4.ok) {
+      const contentLength = response4.headers.get("content-length");
+      console.log(`✅ Auto-redirect Success! Content length: ${contentLength}`);
+    }
+  } catch (error) {
+    console.error("❌ Test failed:", error);
+  }
 }
 
 // Export for use as a VS Code command
 export function activate(context: vscode.ExtensionContext) {
-    const disposable = vscode.commands.registerCommand('nexkit.testGitHubDownload', testGitHubDownload);
-    context.subscriptions.push(disposable);
+  const disposable = vscode.commands.registerCommand(
+    "nexkit.testGitHubDownload",
+    testGitHubDownload
+  );
+  context.subscriptions.push(disposable);
 
-    // Run immediately when activated
-    testGitHubDownload();
+  // Run immediately when activated
+  testGitHubDownload();
 }
 
-export function deactivate() { }
+export function deactivate() {}

--- a/src/test/suite/githubDownloadTest.ts
+++ b/src/test/suite/githubDownloadTest.ts
@@ -1,269 +1,302 @@
-import * as assert from 'assert';
-import * as vscode from 'vscode';
-import { GitHubReleaseService } from '../../githubReleaseService';
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { GitHubReleaseService } from "../../githubReleaseService";
 
 /**
  * Helper function to test keeping auth header through redirects
  */
 async function fetchWithRedirectsKeepAuth(
-    url: string,
-    init: { headers?: Record<string, string>; method?: string } = {},
-    maxRedirects: number = 10
+  url: string,
+  init: { headers?: Record<string, string>; method?: string } = {},
+  maxRedirects: number = 10
 ): Promise<Response> {
-    let currentUrl = url;
-    let redirects = 0;
-    let method = init.method || 'GET';
-    const headers: Record<string, string> = { ...(init.headers || {}) };
+  let currentUrl = url;
+  let redirects = 0;
+  let method = init.method || "GET";
+  const headers: Record<string, string> = { ...(init.headers || {}) };
 
-    while (redirects <= maxRedirects) {
-        console.log(`Fetching: ${currentUrl} (redirect ${redirects})`);
-        const response = await fetch(currentUrl, { headers, method, redirect: 'manual' });
+  while (redirects <= maxRedirects) {
+    console.log(`Fetching: ${currentUrl} (redirect ${redirects})`);
+    const response = await fetch(currentUrl, {
+      headers,
+      method,
+      redirect: "manual",
+    });
 
-        if (![301, 302, 303, 307, 308].includes(response.status)) {
-            return response;
-        }
-
-        const location = response.headers.get('location');
-        if (!location) {
-            return response;
-        }
-
-        redirects += 1;
-        if (redirects > maxRedirects) {
-            throw new Error(`Too many redirects (${redirects})`);
-        }
-
-        const nextUrl = new URL(location, currentUrl).toString();
-        console.log(`Redirect ${redirects}: ${nextUrl}`);
-
-        // KEY DIFFERENCE: Keep the Authorization header for all redirects
-        // (Don't remove it on host change)
-
-        if (response.status === 303) {
-            method = 'GET';
-        }
-
-        currentUrl = nextUrl;
+    if (![301, 302, 303, 307, 308].includes(response.status)) {
+      return response;
     }
 
-    throw new Error('Redirect handling exited unexpectedly');
+    const location = response.headers.get("location");
+    if (!location) {
+      return response;
+    }
+
+    redirects += 1;
+    if (redirects > maxRedirects) {
+      throw new Error(`Too many redirects (${redirects})`);
+    }
+
+    const nextUrl = new URL(location, currentUrl).toString();
+    console.log(`Redirect ${redirects}: ${nextUrl}`);
+
+    // KEY DIFFERENCE: Keep the Authorization header for all redirects
+    // (Don't remove it on host change)
+
+    if (response.status === 303) {
+      method = "GET";
+    }
+
+    currentUrl = nextUrl;
+  }
+
+  throw new Error("Redirect handling exited unexpectedly");
 }
 
 /**
  * Test suite to diagnose GitHub private repository download issues
  */
-suite('GitHub Download Diagnostic Tests', () => {
-    let service: GitHubReleaseService;
-    const testVsixUrl = 'https://github.com/NexusInnovation/nexkit-vscode/releases/download/v0.3.7/nexkit-vscode.vsix';
+suite("GitHub Download Diagnostic Tests", () => {
+  let service: GitHubReleaseService;
+  const testVsixUrl =
+    "https://github.com/NexusInnovation/nexus-nexkit-vscode/releases/download/v0.3.7/nexkit-vscode.vsix";
 
-    setup(() => {
-        const mockContext = {
-            subscriptions: [],
-            workspaceState: {
-                get: () => undefined,
-                update: () => Promise.resolve()
-            },
-            globalState: {
-                get: () => undefined,
-                update: () => Promise.resolve()
-            }
-        } as any;
-        service = new GitHubReleaseService(mockContext);
-    });
+  setup(() => {
+    const mockContext = {
+      subscriptions: [],
+      workspaceState: {
+        get: () => undefined,
+        update: () => Promise.resolve(),
+      },
+      globalState: {
+        get: () => undefined,
+        update: () => Promise.resolve(),
+      },
+    } as any;
+    service = new GitHubReleaseService(mockContext);
+  });
 
-    test('Manual fetch test - Direct URL with headers', async function () {
-        this.timeout(30000); // 30 seconds timeout
+  test("Manual fetch test - Direct URL with headers", async function () {
+    this.timeout(30000); // 30 seconds timeout
 
-        try {
-            // Get authentication session
-            const session = await vscode.authentication.getSession(
-                'github',
-                ['repo'],
-                { createIfNone: true, silent: false }
-            );
+    try {
+      // Get authentication session
+      const session = await vscode.authentication.getSession(
+        "github",
+        ["repo"],
+        { createIfNone: true, silent: false }
+      );
 
-            if (!session) {
-                console.log('No GitHub session available - skipping authenticated test');
-                return;
-            }
+      if (!session) {
+        console.log(
+          "No GitHub session available - skipping authenticated test"
+        );
+        return;
+      }
 
-            console.log('Testing direct fetch with Authorization header...');
+      console.log("Testing direct fetch with Authorization header...");
 
-            const headers = {
-                'User-Agent': 'Nexkit-VSCode-Extension',
-                'Accept': 'application/octet-stream',
-                'Authorization': `Bearer ${session.accessToken}`
-            };
+      const headers = {
+        "User-Agent": "Nexkit-VSCode-Extension",
+        Accept: "application/octet-stream",
+        Authorization: `Bearer ${session.accessToken}`,
+      };
 
-            // Test 1: Direct fetch with manual redirect handling disabled
-            console.log('Test 1: Direct fetch with redirect: "manual"');
-            const response1 = await fetch(testVsixUrl, {
-                headers,
-                redirect: 'manual'
-            });
+      // Test 1: Direct fetch with manual redirect handling disabled
+      console.log('Test 1: Direct fetch with redirect: "manual"');
+      const response1 = await fetch(testVsixUrl, {
+        headers,
+        redirect: "manual",
+      });
 
-            console.log(`Response status: ${response1.status}`);
-            console.log(`Response headers: ${JSON.stringify(Object.fromEntries(response1.headers.entries()), null, 2)}`);
+      console.log(`Response status: ${response1.status}`);
+      console.log(
+        `Response headers: ${JSON.stringify(
+          Object.fromEntries(response1.headers.entries()),
+          null,
+          2
+        )}`
+      );
 
-            if (response1.status >= 300 && response1.status < 400) {
-                const location = response1.headers.get('location');
-                console.log(`Redirect location: ${location}`);
+      if (response1.status >= 300 && response1.status < 400) {
+        const location = response1.headers.get("location");
+        console.log(`Redirect location: ${location}`);
 
-                if (location) {
-                    // Test the redirect location
-                    console.log('Test 2: Following redirect manually with Auth header');
-                    const redirectUrl = new URL(location, testVsixUrl).toString();
-                    console.log(`Redirect URL: ${redirectUrl}`);
+        if (location) {
+          // Test the redirect location
+          console.log("Test 2: Following redirect manually with Auth header");
+          const redirectUrl = new URL(location, testVsixUrl).toString();
+          console.log(`Redirect URL: ${redirectUrl}`);
 
-                    const response2 = await fetch(redirectUrl, {
-                        headers,
-                        redirect: 'manual'
-                    });
+          const response2 = await fetch(redirectUrl, {
+            headers,
+            redirect: "manual",
+          });
 
-                    console.log(`Redirect response status: ${response2.status}`);
-                    console.log(`Redirect response headers: ${JSON.stringify(Object.fromEntries(response2.headers.entries()), null, 2)}`);
+          console.log(`Redirect response status: ${response2.status}`);
+          console.log(
+            `Redirect response headers: ${JSON.stringify(
+              Object.fromEntries(response2.headers.entries()),
+              null,
+              2
+            )}`
+          );
 
-                    // Test 3: Following redirect without Auth header
-                    console.log('Test 3: Following redirect without Auth header');
-                    const headersNoAuth = {
-                        'User-Agent': 'Nexkit-VSCode-Extension',
-                        'Accept': 'application/octet-stream'
-                    };
+          // Test 3: Following redirect without Auth header
+          console.log("Test 3: Following redirect without Auth header");
+          const headersNoAuth = {
+            "User-Agent": "Nexkit-VSCode-Extension",
+            Accept: "application/octet-stream",
+          };
 
-                    const response3 = await fetch(redirectUrl, {
-                        headers: headersNoAuth,
-                        redirect: 'manual'
-                    });
+          const response3 = await fetch(redirectUrl, {
+            headers: headersNoAuth,
+            redirect: "manual",
+          });
 
-                    console.log(`No-auth redirect response status: ${response3.status}`);
-                    console.log(`No-auth redirect response headers: ${JSON.stringify(Object.fromEntries(response3.headers.entries()), null, 2)}`);
-                }
-            }
-
-            // Test 4: Let browser handle redirects automatically
-            console.log('Test 4: Automatic redirect handling');
-            const response4 = await fetch(testVsixUrl, {
-                headers,
-                redirect: 'follow'
-            });
-
-            console.log(`Auto-redirect response status: ${response4.status}`);
-            console.log(`Auto-redirect final URL: ${response4.url}`);
-
-            if (response4.ok) {
-                const contentLength = response4.headers.get('content-length');
-                console.log(`Content length: ${contentLength}`);
-                console.log('✅ Download successful with automatic redirects!');
-            }
-
-        } catch (error) {
-            console.error('Test failed:', error);
-            throw error;
+          console.log(`No-auth redirect response status: ${response3.status}`);
+          console.log(
+            `No-auth redirect response headers: ${JSON.stringify(
+              Object.fromEntries(response3.headers.entries()),
+              null,
+              2
+            )}`
+          );
         }
-    });
+      }
 
-    test('Test custom fetchWithRedirects method', async function () {
-        this.timeout(30000);
+      // Test 4: Let browser handle redirects automatically
+      console.log("Test 4: Automatic redirect handling");
+      const response4 = await fetch(testVsixUrl, {
+        headers,
+        redirect: "follow",
+      });
 
-        try {
-            const session = await vscode.authentication.getSession(
-                'github',
-                ['repo'],
-                { createIfNone: true, silent: false }
-            );
+      console.log(`Auto-redirect response status: ${response4.status}`);
+      console.log(`Auto-redirect final URL: ${response4.url}`);
 
-            if (!session) {
-                console.log('No GitHub session available - skipping test');
-                return;
-            }
+      if (response4.ok) {
+        const contentLength = response4.headers.get("content-length");
+        console.log(`Content length: ${contentLength}`);
+        console.log("✅ Download successful with automatic redirects!");
+      }
+    } catch (error) {
+      console.error("Test failed:", error);
+      throw error;
+    }
+  });
 
-            console.log('Testing custom fetchWithRedirects method...');
+  test("Test custom fetchWithRedirects method", async function () {
+    this.timeout(30000);
 
-            // We'll test the downloadVsixAsset method which uses fetchWithRedirects internally
-            // First get the release info
-            const release = await service.fetchLatestRelease();
-            console.log(`Found release: ${release.tagName}`);
+    try {
+      const session = await vscode.authentication.getSession(
+        "github",
+        ["repo"],
+        { createIfNone: true, silent: false }
+      );
 
-            // Try to download the vsix
-            console.log('Attempting to download VSIX using service method...');
-            const vsixData = await service.downloadVsixAsset(release);
+      if (!session) {
+        console.log("No GitHub session available - skipping test");
+        return;
+      }
 
-            console.log(`✅ Downloaded ${vsixData.byteLength} bytes successfully!`);
+      console.log("Testing custom fetchWithRedirects method...");
 
-        } catch (error) {
-            console.error('Custom method test failed:', error);
-            throw error;
+      // We'll test the downloadVsixAsset method which uses fetchWithRedirects internally
+      // First get the release info
+      const release = await service.fetchLatestRelease();
+      console.log(`Found release: ${release.tagName}`);
+
+      // Try to download the vsix
+      console.log("Attempting to download VSIX using service method...");
+      const vsixData = await service.downloadVsixAsset(release);
+
+      console.log(`✅ Downloaded ${vsixData.byteLength} bytes successfully!`);
+    } catch (error) {
+      console.error("Custom method test failed:", error);
+      throw error;
+    }
+  });
+
+  test("Compare download approaches for private repository", async function () {
+    this.timeout(60000); // Increase timeout for downloads
+
+    try {
+      const session = await vscode.authentication.getSession(
+        "github",
+        ["repo"],
+        { createIfNone: true, silent: false }
+      );
+
+      if (!session) {
+        console.log("No GitHub session available - skipping test");
+        return;
+      }
+
+      console.log("Testing different download approaches...");
+
+      // Test the service's download method
+      const release = await service.fetchLatestRelease();
+      console.log(`Testing with release: ${release.tagName}`);
+
+      try {
+        console.log(
+          "🔧 Testing new approach (GitHub API + improved redirect handling)..."
+        );
+        const vsixData = await service.downloadVsixAsset(release);
+        console.log(`✅ New approach: SUCCESS (${vsixData.byteLength} bytes)`);
+
+        // Verify it's a valid ZIP file
+        const uint8Array = new Uint8Array(vsixData);
+        const header = Array.from(uint8Array.slice(0, 4))
+          .map((b) => b.toString(16).padStart(2, "0"))
+          .join("");
+        if (header === "504b0304") {
+          console.log("✅ Downloaded file has valid ZIP/VSIX header");
+        } else {
+          console.log(
+            `⚠️  Downloaded file header: ${header} (expected: 504b0304)`
+          );
         }
-    });
+      } catch (error) {
+        console.log(`❌ New approach: FAILED - ${error}`);
+      }
 
-    test('Compare download approaches for private repository', async function () {
-        this.timeout(60000); // Increase timeout for downloads
+      // Test manual fetch with different strategies
+      const headers = {
+        "User-Agent": "Nexkit-VSCode-Extension",
+        Accept: "application/octet-stream",
+        Authorization: `Bearer ${session.accessToken}`,
+      };
 
+      console.log("\n🔧 Testing direct browser_download_url...");
+      const vsixAsset = release.assets.find((asset) =>
+        asset.name.endsWith(".vsix")
+      );
+      if (vsixAsset) {
         try {
-            const session = await vscode.authentication.getSession(
-                'github',
-                ['repo'],
-                { createIfNone: true, silent: false }
+          const response = await fetch(vsixAsset.browserDownloadUrl, {
+            headers,
+            redirect: "follow", // Let fetch handle redirects automatically
+          });
+
+          if (response.ok) {
+            const data = await response.arrayBuffer();
+            console.log(
+              `✅ Direct URL with auto-redirect: SUCCESS (${data.byteLength} bytes)`
             );
-
-            if (!session) {
-                console.log('No GitHub session available - skipping test');
-                return;
-            }
-
-            console.log('Testing different download approaches...');
-
-            // Test the service's download method
-            const release = await service.fetchLatestRelease();
-            console.log(`Testing with release: ${release.tagName}`);
-
-            try {
-                console.log('🔧 Testing new approach (GitHub API + improved redirect handling)...');
-                const vsixData = await service.downloadVsixAsset(release);
-                console.log(`✅ New approach: SUCCESS (${vsixData.byteLength} bytes)`);
-
-                // Verify it's a valid ZIP file
-                const uint8Array = new Uint8Array(vsixData);
-                const header = Array.from(uint8Array.slice(0, 4)).map(b => b.toString(16).padStart(2, '0')).join('');
-                if (header === '504b0304') {
-                    console.log('✅ Downloaded file has valid ZIP/VSIX header');
-                } else {
-                    console.log(`⚠️  Downloaded file header: ${header} (expected: 504b0304)`);
-                }
-
-            } catch (error) {
-                console.log(`❌ New approach: FAILED - ${error}`);
-            }
-
-            // Test manual fetch with different strategies
-            const headers = {
-                'User-Agent': 'Nexkit-VSCode-Extension',
-                'Accept': 'application/octet-stream',
-                'Authorization': `Bearer ${session.accessToken}`
-            };
-
-            console.log('\n🔧 Testing direct browser_download_url...');
-            const vsixAsset = release.assets.find(asset => asset.name.endsWith('.vsix'));
-            if (vsixAsset) {
-                try {
-                    const response = await fetch(vsixAsset.browserDownloadUrl, {
-                        headers,
-                        redirect: 'follow' // Let fetch handle redirects automatically
-                    });
-
-                    if (response.ok) {
-                        const data = await response.arrayBuffer();
-                        console.log(`✅ Direct URL with auto-redirect: SUCCESS (${data.byteLength} bytes)`);
-                    } else {
-                        console.log(`❌ Direct URL: FAILED - ${response.status} ${response.statusText}`);
-                    }
-                } catch (error) {
-                    console.log(`❌ Direct URL: FAILED - ${error}`);
-                }
-            }
-
+          } else {
+            console.log(
+              `❌ Direct URL: FAILED - ${response.status} ${response.statusText}`
+            );
+          }
         } catch (error) {
-            console.error('Download comparison test failed:', error);
+          console.log(`❌ Direct URL: FAILED - ${error}`);
         }
-    });
+      }
+    } catch (error) {
+      console.error("Download comparison test failed:", error);
+    }
+  });
 });


### PR DESCRIPTION
✅ Repo rename wired through (without changing the VSIX asset name)
All GitHub repository references used for releases/updates were updated from NexusInnovation/nexkit-vscode → NexusInnovation/nexus-nexkit-vscode, while keeping the VSIX asset name as nexkit-vscode.vsix (and the temp filename pattern nexkit-vscode-<version>.vsix) exactly as-is.

Files updated
githubReleaseService.ts — points API calls at nexus-nexkit-vscode
extensionUpdateManager.ts — “View Release Notes” now opens the renamed repo’s release page
downloadDiagnostic.ts — updated diagnostic download URL
githubDownloadTest.ts — updated diagnostic test URL
test-github-download.js — updated test URL
package.json — updated "repository.url"
README.md, CONTRIBUTING.md — updated clone/issue/release links and badges
Verification
Ran npm test (includes tsc -p ./, ESLint, and VS Code extension tests): pass (exit code 0).
Note
git status currently shows untracked agents and prompts files in your working tree. They weren’t needed for the repo rename itself—so you may want to decide separately whether to commit them or remove them to keep this branch focused.

Todo list (final)
Scan repo-name references — completed
Update runtime GitHub URLs — completed
Update tests/diagnostic URLs — completed
Update docs and metadata URLs — completed
Run npm test — completed