### PR TITLE
chore(release): Use tabs to select section in NexKit panel

### DIFF
--- a/src/features/github-workflow-runner/githubWorkflowRunnerService.ts
+++ b/src/features/github-workflow-runner/githubWorkflowRunnerService.ts
@@ -165,9 +165,7 @@ export class GitHubWorkflowRunnerService {
     }
 
     if (!this.isDockerRunning()) {
-      vscode.window.showErrorMessage(
-        "Docker is installed but not running. Please start Docker Desktop and try again."
-      );
+      vscode.window.showErrorMessage("Docker is installed but not running. Please start Docker Desktop and try again.");
       return;
     }
 

--- a/src/features/github-workflow-runner/githubWorkflowRunnerService.ts
+++ b/src/features/github-workflow-runner/githubWorkflowRunnerService.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as fs from "fs";
 import * as path from "path";
-import { execSync } from "child_process";
+import { exec, execSync } from "child_process";
 
 /**
  * Install commands for act, ordered by preference
@@ -170,7 +170,7 @@ export class GitHubWorkflowRunnerService {
       return;
     }
 
-    if (!this.isDockerRunning()) {
+    if (!(await this.isDockerRunning())) {
       vscode.window.showErrorMessage("Docker is installed but not running. Please start Docker Desktop and try again.");
       return;
     }
@@ -218,13 +218,21 @@ export class GitHubWorkflowRunnerService {
   /**
    * Checks whether the Docker daemon is currently running.
    */
-  public isDockerRunning(): boolean {
-    try {
-      execSync("docker info", { encoding: "utf-8", timeout: 10000, stdio: "pipe" });
-      return true;
-    } catch {
-      return false;
-    }
+  public isDockerRunning(): Promise<boolean> {
+    return new Promise((resolve) => {
+      let settled = false;
+      const settle = (result: boolean) => {
+        if (!settled) {
+          settled = true;
+          resolve(result);
+        }
+      };
+      const proc = exec("docker info", { timeout: 10000 });
+      proc.stdout?.resume();
+      proc.stderr?.resume();
+      proc.on("close", (code) => settle(code === 0));
+      proc.on("error", () => settle(false));
+    });
   }
 
   /**

--- a/src/features/github-workflow-runner/githubWorkflowRunnerService.ts
+++ b/src/features/github-workflow-runner/githubWorkflowRunnerService.ts
@@ -159,7 +159,13 @@ export class GitHubWorkflowRunnerService {
         "Open Docker Install Page"
       );
       if (action === "Open Docker Install Page") {
-        vscode.env.openExternal(vscode.Uri.parse("https://www.docker.com/products/docker-desktop/"));
+        try {
+          await vscode.env.openExternal(vscode.Uri.parse("https://www.docker.com/products/docker-desktop/"));
+        } catch (err) {
+          void vscode.window.showErrorMessage(
+            "Failed to open Docker install page. Please open it manually: https://www.docker.com/products/docker-desktop/"
+          );
+        }
       }
       return;
     }

--- a/src/features/github-workflow-runner/githubWorkflowRunnerService.ts
+++ b/src/features/github-workflow-runner/githubWorkflowRunnerService.ts
@@ -141,6 +141,7 @@ export class GitHubWorkflowRunnerService {
   /**
    * Runs a workflow locally by invoking `act` directly in a VS Code terminal.
    *
+   * If Docker is not installed or not running, shows an error message.
    * If `act` is not installed, prompts the user to install it automatically
    * via winget, chocolatey, or scoop.
    */
@@ -148,6 +149,25 @@ export class GitHubWorkflowRunnerService {
     const workspaceFolders = vscode.workspace.workspaceFolders;
     if (!workspaceFolders || workspaceFolders.length === 0) {
       vscode.window.showErrorMessage("No workspace folder open.");
+      return;
+    }
+
+    // Check if Docker is installed and running
+    if (!this.isDockerInstalled()) {
+      const action = await vscode.window.showErrorMessage(
+        "Docker is required to run GitHub workflows locally but was not found. Please install Docker Desktop and try again.",
+        "Open Docker Install Page"
+      );
+      if (action === "Open Docker Install Page") {
+        vscode.env.openExternal(vscode.Uri.parse("https://www.docker.com/products/docker-desktop/"));
+      }
+      return;
+    }
+
+    if (!this.isDockerRunning()) {
+      vscode.window.showErrorMessage(
+        "Docker is installed but not running. Please start Docker Desktop and try again."
+      );
       return;
     }
 
@@ -182,6 +202,25 @@ export class GitHubWorkflowRunnerService {
    */
   public isActInstalled(): boolean {
     return this.findActPath() !== undefined;
+  }
+
+  /**
+   * Checks whether Docker is installed on the system.
+   */
+  public isDockerInstalled(): boolean {
+    return this.resolveFromPath("docker") !== undefined;
+  }
+
+  /**
+   * Checks whether the Docker daemon is currently running.
+   */
+  public isDockerRunning(): boolean {
+    try {
+      execSync("docker info", { encoding: "utf-8", timeout: 10000, stdio: "pipe" });
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/src/features/panel-ui/webview/components/App.tsx
+++ b/src/features/panel-ui/webview/components/App.tsx
@@ -1,8 +1,8 @@
-import { useMemo } from "preact/hooks";
+import { useEffect, useMemo } from "preact/hooks";
 import { useAppState } from "../hooks/useAppState";
 import { useMode } from "../hooks/useMode";
 import { useActiveTab } from "../hooks/useActiveTab";
-import { ActionsSection } from "./organisms/ActionsSection";
+import { useWebviewPersistentState } from "../hooks/useWebviewPersistentState";
 import { ApmActionsSection } from "./organisms/ApmActionsSection";
 import { FooterSection } from "./organisms/FooterSection";
 import { ProfileSection } from "./organisms/ProfileSection";
@@ -24,8 +24,9 @@ const TAB_DEFINITIONS: Record<string, TabDefinition> = {
  * Root component for the Nexkit webview panel
  */
 export function App() {
-  const { workspace } = useAppState();
+  const { workspace, profiles } = useAppState();
   const { isNoneMode, isDevelopersMode, isAPMMode } = useMode();
+  const { getWebviewState, setWebviewState } = useWebviewPersistentState();
 
   // Build the list of visible tabs based on the current mode
   const tabs = useMemo<TabDefinition[]>(() => {
@@ -40,6 +41,37 @@ export function App() {
 
   const tabIds = useMemo(() => tabs.map((t) => t.id), [tabs]);
   const [activeTab, setActiveTab] = useActiveTab(tabIds);
+
+  // Clear profile badge when the user visits the profile tab
+  useEffect(() => {
+    if (activeTab === "profile" && profiles.isReady) {
+      const state = getWebviewState();
+      if (state.lastSeenProfileCount !== profiles.list.length) {
+        state.lastSeenProfileCount = profiles.list.length;
+        setWebviewState(state);
+      }
+    }
+  }, [activeTab, profiles.list.length, profiles.isReady]);
+
+  // Compute tab badges
+  const badges = useMemo<Record<string, boolean>>(() => {
+    const result: Record<string, boolean> = {};
+
+    // Tools badge: workspace needs initialization
+    if (isDevelopersMode && !workspace.isInitialized) {
+      result.tools = true;
+    }
+
+    // Profile badge: new profile saved since last visit (hidden while viewing)
+    if (isDevelopersMode && profiles.isReady && activeTab !== "profile") {
+      const lastSeen = getWebviewState().lastSeenProfileCount;
+      if (lastSeen !== undefined && profiles.list.length > lastSeen) {
+        result.profile = true;
+      }
+    }
+
+    return result;
+  }, [isDevelopersMode, workspace.isInitialized, profiles.isReady, profiles.list.length, activeTab]);
 
   if (!workspace.isReady) {
     return null;
@@ -62,16 +94,15 @@ export function App() {
 
   return (
     <div class="container">
-      {isDevelopersMode && <ActionsSection isInitialized={workspace.isInitialized} />}
       {isAPMMode && <ApmActionsSection isInitialized={workspace.isInitialized} />}
 
-      <TabBar tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab} />
+      <TabBar tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab} badges={badges} />
 
       <div class="tab-content" role="tabpanel">
         {isDevelopersMode && (
           <>
             {activeTab === "template" && <TemplateSection />}
-            {activeTab === "tools" && <ToolsSection />}
+            {activeTab === "tools" && <ToolsSection isInitialized={workspace.isInitialized} />}
             {activeTab === "profile" && <ProfileSection />}
           </>
         )}

--- a/src/features/panel-ui/webview/components/App.tsx
+++ b/src/features/panel-ui/webview/components/App.tsx
@@ -1,7 +1,9 @@
+import { useMemo } from "preact/hooks";
 import { useAppState } from "../hooks/useAppState";
 import { useMode } from "../hooks/useMode";
-import { ApmActionsSection } from "./organisms/ApmActionsSection";
+import { useActiveTab } from "../hooks/useActiveTab";
 import { ActionsSection } from "./organisms/ActionsSection";
+import { ApmActionsSection } from "./organisms/ApmActionsSection";
 import { FooterSection } from "./organisms/FooterSection";
 import { ProfileSection } from "./organisms/ProfileSection";
 import { TemplateSection } from "./organisms/TemplateSection";
@@ -9,6 +11,14 @@ import { ApmConnectionSection } from "./organisms/ApmConnectionSection";
 import { ApmTemplateSection } from "./organisms/ApmTemplateSection";
 import { ModeSelectionSection } from "./organisms/ModeSelectionSection";
 import { ToolsSection } from "./organisms/ToolsSection";
+import { TabBar, TabDefinition } from "./molecules/TabBar";
+
+const TAB_DEFINITIONS: Record<string, TabDefinition> = {
+  template: { id: "template", icon: "file-code", label: "Templates" },
+  project: { id: "project", icon: "azure-devops", label: "Project" },
+  tools: { id: "tools", icon: "tools", label: "Tools" },
+  profile: { id: "profile", icon: "account", label: "Profiles" },
+};
 
 /**
  * Root component for the Nexkit webview panel
@@ -16,6 +26,20 @@ import { ToolsSection } from "./organisms/ToolsSection";
 export function App() {
   const { workspace } = useAppState();
   const { isNoneMode, isDevelopersMode, isAPMMode } = useMode();
+
+  // Build the list of visible tabs based on the current mode
+  const tabs = useMemo<TabDefinition[]>(() => {
+    if (isDevelopersMode) {
+      return [TAB_DEFINITIONS.template, TAB_DEFINITIONS.tools, TAB_DEFINITIONS.profile];
+    }
+    if (isAPMMode) {
+      return [TAB_DEFINITIONS.template, TAB_DEFINITIONS.project];
+    }
+    return [];
+  }, [isDevelopersMode, isAPMMode]);
+
+  const tabIds = useMemo(() => tabs.map((t) => t.id), [tabs]);
+  const [activeTab, setActiveTab] = useActiveTab(tabIds);
 
   if (!workspace.isReady) {
     return null;
@@ -38,21 +62,27 @@ export function App() {
 
   return (
     <div class="container">
-      {isDevelopersMode && (
-        <>
-          <ActionsSection isInitialized={workspace.isInitialized} />
-          <ProfileSection />
-          <TemplateSection />
-          <ToolsSection />
-        </>
-      )}
-      {isAPMMode && (
-        <>
-          <ApmTemplateSection />
-          <ApmActionsSection isInitialized={workspace.isInitialized} />
-          <ApmConnectionSection />
-        </>
-      )}
+      {isDevelopersMode && <ActionsSection isInitialized={workspace.isInitialized} />}
+      {isAPMMode && <ApmActionsSection isInitialized={workspace.isInitialized} />}
+
+      <TabBar tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab} />
+
+      <div class="tab-content" role="tabpanel">
+        {isDevelopersMode && (
+          <>
+            {activeTab === "template" && <TemplateSection />}
+            {activeTab === "tools" && <ToolsSection />}
+            {activeTab === "profile" && <ProfileSection />}
+          </>
+        )}
+        {isAPMMode && (
+          <>
+            {activeTab === "template" && <ApmTemplateSection />}
+            {activeTab === "project" && <ApmConnectionSection />}
+          </>
+        )}
+      </div>
+
       <FooterSection />
     </div>
   );

--- a/src/features/panel-ui/webview/components/App.tsx
+++ b/src/features/panel-ui/webview/components/App.tsx
@@ -98,18 +98,38 @@ export function App() {
 
       <TabBar tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab} badges={badges} />
 
-      <div class="tab-content" role="tabpanel">
+      <div class="tab-content">
         {isDevelopersMode && (
           <>
-            {activeTab === "template" && <TemplateSection />}
-            {activeTab === "tools" && <ToolsSection isInitialized={workspace.isInitialized} />}
-            {activeTab === "profile" && <ProfileSection />}
+            {activeTab === "template" && (
+              <div class="tab-panel" role="tabpanel" id="template-tabpanel">
+                <TemplateSection />
+              </div>
+            )}
+            {activeTab === "tools" && (
+              <div class="tab-panel" role="tabpanel" id="tools-tabpanel">
+                <ToolsSection isInitialized={workspace.isInitialized} />
+              </div>
+            )}
+            {activeTab === "profile" && (
+              <div class="tab-panel" role="tabpanel" id="profile-tabpanel">
+                <ProfileSection />
+              </div>
+            )}
           </>
         )}
         {isAPMMode && (
           <>
-            {activeTab === "template" && <ApmTemplateSection />}
-            {activeTab === "project" && <ApmConnectionSection />}
+            {activeTab === "template" && (
+              <div class="tab-panel" role="tabpanel" id="template-tabpanel">
+                <ApmTemplateSection />
+              </div>
+            )}
+            {activeTab === "project" && (
+              <div class="tab-panel" role="tabpanel" id="project-tabpanel">
+                <ApmConnectionSection />
+              </div>
+            )}
           </>
         )}
       </div>

--- a/src/features/panel-ui/webview/components/App.tsx
+++ b/src/features/panel-ui/webview/components/App.tsx
@@ -53,6 +53,17 @@ export function App() {
     }
   }, [activeTab, profiles.list.length, profiles.isReady]);
 
+  // Initialize lastSeenProfileCount when profiles first become ready
+  useEffect(() => {
+    if (isDevelopersMode && profiles.isReady) {
+      const state = getWebviewState();
+      if (state.lastSeenProfileCount === undefined) {
+        state.lastSeenProfileCount = profiles.list.length;
+        setWebviewState(state);
+      }
+    }
+  }, [isDevelopersMode, profiles.isReady, profiles.list.length]);
+
   // Compute tab badges
   const badges = useMemo<Record<string, boolean>>(() => {
     const result: Record<string, boolean> = {};

--- a/src/features/panel-ui/webview/components/molecules/TabBar.tsx
+++ b/src/features/panel-ui/webview/components/molecules/TabBar.tsx
@@ -19,11 +19,15 @@ interface TabBarProps {
  */
 export function TabBar({ tabs, activeTab, onTabChange, badges }: TabBarProps): JSX.Element {
   return (
-    <div class="tab-bar">
+    <div class="tab-bar" role="tablist">
       {tabs.map((tab) => (
         <button
           key={tab.id}
+          id={`tab-${tab.id}`}
           class={`tab-button ${activeTab === tab.id ? "active" : ""}`}
+          role="tab"
+          aria-selected={activeTab === tab.id}
+          aria-controls={`panel-${tab.id}`}
           aria-label={tab.label}
           title={tab.label}
           onClick={() => onTabChange(tab.id)}

--- a/src/features/panel-ui/webview/components/molecules/TabBar.tsx
+++ b/src/features/panel-ui/webview/components/molecules/TabBar.tsx
@@ -10,13 +10,14 @@ interface TabBarProps {
   tabs: TabDefinition[];
   activeTab: string;
   onTabChange: (tabId: string) => void;
+  badges?: Record<string, boolean>;
 }
 
 /**
  * TabBar Component
  * Renders a horizontal icon tab bar for switching between panel sections.
  */
-export function TabBar({ tabs, activeTab, onTabChange }: TabBarProps): JSX.Element {
+export function TabBar({ tabs, activeTab, onTabChange, badges }: TabBarProps): JSX.Element {
   return (
     <div class="tab-bar" role="tablist">
       {tabs.map((tab) => (
@@ -29,7 +30,10 @@ export function TabBar({ tabs, activeTab, onTabChange }: TabBarProps): JSX.Eleme
           title={tab.label}
           onClick={() => onTabChange(tab.id)}
         >
-          <i class={`codicon codicon-${tab.icon}`} />
+          <span class="tab-icon-wrapper">
+            <i class={`codicon codicon-${tab.icon}`} />
+            {badges?.[tab.id] && <span class="tab-badge" />}
+          </span>
         </button>
       ))}
     </div>

--- a/src/features/panel-ui/webview/components/molecules/TabBar.tsx
+++ b/src/features/panel-ui/webview/components/molecules/TabBar.tsx
@@ -1,0 +1,37 @@
+import { JSX } from "preact";
+
+export interface TabDefinition {
+  id: string;
+  icon: string;
+  label: string;
+}
+
+interface TabBarProps {
+  tabs: TabDefinition[];
+  activeTab: string;
+  onTabChange: (tabId: string) => void;
+}
+
+/**
+ * TabBar Component
+ * Renders a horizontal icon tab bar for switching between panel sections.
+ */
+export function TabBar({ tabs, activeTab, onTabChange }: TabBarProps): JSX.Element {
+  return (
+    <div class="tab-bar" role="tablist">
+      {tabs.map((tab) => (
+        <button
+          key={tab.id}
+          class={`tab-button ${activeTab === tab.id ? "active" : ""}`}
+          role="tab"
+          aria-selected={activeTab === tab.id}
+          aria-label={tab.label}
+          title={tab.label}
+          onClick={() => onTabChange(tab.id)}
+        >
+          <i class={`codicon codicon-${tab.icon}`} />
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/features/panel-ui/webview/components/molecules/TabBar.tsx
+++ b/src/features/panel-ui/webview/components/molecules/TabBar.tsx
@@ -19,13 +19,11 @@ interface TabBarProps {
  */
 export function TabBar({ tabs, activeTab, onTabChange, badges }: TabBarProps): JSX.Element {
   return (
-    <div class="tab-bar" role="tablist">
+    <div class="tab-bar">
       {tabs.map((tab) => (
         <button
           key={tab.id}
           class={`tab-button ${activeTab === tab.id ? "active" : ""}`}
-          role="tab"
-          aria-selected={activeTab === tab.id}
           aria-label={tab.label}
           title={tab.label}
           onClick={() => onTabChange(tab.id)}

--- a/src/features/panel-ui/webview/components/organisms/ApmConnectionSection.tsx
+++ b/src/features/panel-ui/webview/components/organisms/ApmConnectionSection.tsx
@@ -1,5 +1,4 @@
 import { useState } from "preact/hooks";
-import { CollapsibleSection } from "../molecules/CollapsibleSection";
 import { useDevOpsConnections } from "../../hooks/useDevOpsConnections";
 
 /**
@@ -65,83 +64,81 @@ export function ApmConnectionSection() {
   const displayError = localError || error;
 
   return (
-    <CollapsibleSection id="connections" title="DevOps Projects" defaultExpanded>
-      <>
-        {!isReady && <p class="loading">Loading projects...</p>}
+    <>
+      {!isReady && <p class="loading">Loading projects...</p>}
 
-        {isReady && (
-          <>
-            {/* Connection List */}
-            {connections.length === 0 && !isAddingNew && (
-              <p class="empty-message">No DevOps projects configured. Add a project to enable Azure DevOps MCP integration.</p>
-            )}
+      {isReady && (
+        <>
+          {/* Connection List */}
+          {connections.length === 0 && !isAddingNew && (
+            <p class="empty-message">No DevOps projects configured. Add a project to enable Azure DevOps MCP integration.</p>
+          )}
 
-            {connections.length > 0 && (
-              <div class="connections-list">
-                {connections.map((connection) => (
-                  <div
-                    key={connection.id}
-                    class={`connection-item ${connection.isActive ? "active" : "inactive"}`}
-                    onClick={() => handleConnectionClick(connection)}
-                    title={connection.isActive ? "Active project" : "Click to make this the active project"}
-                  >
-                    <div class="connection-info">
-                      <div class="connection-name">
-                        {connection.isActive && <i class="codicon codicon-circle-filled connection-active-icon"></i>}
-                        {!connection.isActive && <i class="codicon codicon-circle-outline connection-inactive-icon"></i>}
-                        {connection.organization}/{connection.project}
-                      </div>
-                      {connection.isActive && <div class="connection-details">Active • MCP: azure-devops</div>}
+          {connections.length > 0 && (
+            <div class="connections-list">
+              {connections.map((connection) => (
+                <div
+                  key={connection.id}
+                  class={`connection-item ${connection.isActive ? "active" : "inactive"}`}
+                  onClick={() => handleConnectionClick(connection)}
+                  title={connection.isActive ? "Active project" : "Click to make this the active project"}
+                >
+                  <div class="connection-info">
+                    <div class="connection-name">
+                      {connection.isActive && <i class="codicon codicon-circle-filled connection-active-icon"></i>}
+                      {!connection.isActive && <i class="codicon codicon-circle-outline connection-inactive-icon"></i>}
+                      {connection.organization}/{connection.project}
                     </div>
-                    <div class="connection-actions">
-                      <button
-                        class="connection-action-button delete-button"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          removeConnection(connection.id);
-                        }}
-                        title={`Remove project "${connection.organization}/${connection.project}"`}
-                      >
-                        <i class="codicon codicon-trash"></i>
-                      </button>
-                    </div>
+                    {connection.isActive && <div class="connection-details">Active • MCP: azure-devops</div>}
                   </div>
-                ))}
-              </div>
-            )}
-
-            {/* Add New Connection Form */}
-            {isAddingNew ? (
-              <div class="add-connection-form">
-                <input
-                  type="text"
-                  class="connection-url-input"
-                  placeholder="https://dev.azure.com/org/project"
-                  value={newUrl}
-                  onInput={(e) => setNewUrl((e.target as HTMLInputElement).value)}
-                  onKeyDown={handleKeyDown}
-                  autofocus
-                />
-                <div class="add-connection-actions">
-                  <button class="button secondary" onClick={handleCancelAdd}>
-                    Cancel
-                  </button>
-                  <button class="button primary" onClick={handleSubmitUrl}>
-                    Add
-                  </button>
+                  <div class="connection-actions">
+                    <button
+                      class="connection-action-button delete-button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        removeConnection(connection.id);
+                      }}
+                      title={`Remove project "${connection.organization}/${connection.project}"`}
+                    >
+                      <i class="codicon codicon-trash"></i>
+                    </button>
+                  </div>
                 </div>
-              </div>
-            ) : (
-              <button class="button add-connection-button" onClick={handleAddClick}>
-                <i class="codicon codicon-add"></i> Add Project
-              </button>
-            )}
+              ))}
+            </div>
+          )}
 
-            {/* Error Display */}
-            {displayError && <div class="connection-error">{displayError}</div>}
-          </>
-        )}
-      </>
-    </CollapsibleSection>
+          {/* Add New Connection Form */}
+          {isAddingNew ? (
+            <div class="add-connection-form">
+              <input
+                type="text"
+                class="connection-url-input"
+                placeholder="https://dev.azure.com/org/project"
+                value={newUrl}
+                onInput={(e) => setNewUrl((e.target as HTMLInputElement).value)}
+                onKeyDown={handleKeyDown}
+                autofocus
+              />
+              <div class="add-connection-actions">
+                <button class="button secondary" onClick={handleCancelAdd}>
+                  Cancel
+                </button>
+                <button class="button primary" onClick={handleSubmitUrl}>
+                  Add
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button class="button add-connection-button" onClick={handleAddClick}>
+              <i class="codicon codicon-add"></i> Add Project
+            </button>
+          )}
+
+          {/* Error Display */}
+          {displayError && <div class="connection-error">{displayError}</div>}
+        </>
+      )}
+    </>
   );
 }

--- a/src/features/panel-ui/webview/components/organisms/ApmTemplateSection.tsx
+++ b/src/features/panel-ui/webview/components/organisms/ApmTemplateSection.tsx
@@ -3,7 +3,6 @@ import { useDebounce } from "../../hooks/useDebounce";
 import { SearchBar } from "../atoms/SearchBar";
 import { useTemplateData } from "../../hooks/useTemplateData";
 import { TemplateMetadataProvider } from "../../contexts/TemplateMetadataContext";
-import { CollapsibleSection } from "../molecules/CollapsibleSection";
 import { TemplateItem } from "../atoms/TemplateItem";
 import { AITemplateFile, OperationMode } from "../../../../ai-template-files/models/aiTemplateFile";
 import { useVSCodeAPI } from "../../hooks/useVSCodeAPI";
@@ -79,50 +78,48 @@ export function ApmTemplateSection() {
   };
 
   return (
-    <CollapsibleSection id="apm-templates" title="Agent Templates" defaultExpanded>
-      <>
-        {!isReady && <p class="loading">Loading agent templates...</p>}
-        {isReady && (
-          <div class="template-section">
-            {installedAgentsCount > 0 && (
-              <div class="action-item">
-                <button
-                  class="action-button"
-                  onClick={updateInstalledTemplates}
-                  title="Update all installed agents to their latest versions from repositories."
-                >
-                  <span>Update Installed Templates ({installedAgentsCount})</span>
-                </button>
-              </div>
-            )}
-            <SearchBar
-              value={searchQuery}
-              onChange={setSearchQuery}
-              placeholder="Search agents..."
-              isScanning={metadataScan.isScanning}
-              isScanComplete={metadataScan.isComplete}
-            />
-            <TemplateMetadataProvider>
-              <div class="apm-agents-list">
-                {filteredAgents.length === 0 && (
-                  <p class="empty-message">
-                    {debouncedSearchQuery ? "No agents match your search." : "No agent templates available."}
-                  </p>
-                )}
-                {filteredAgents.map((agent) => (
-                  <TemplateItem
-                    key={`${agent.repository}::${agent.name}`}
-                    template={agent}
-                    isInstalled={isTemplateInstalled(agent)}
-                    onInstall={() => installTemplate(agent)}
-                    onUninstall={() => uninstallTemplate(agent)}
-                  />
-                ))}
-              </div>
-            </TemplateMetadataProvider>
-          </div>
-        )}
-      </>
-    </CollapsibleSection>
+    <>
+      {!isReady && <p class="loading">Loading agent templates...</p>}
+      {isReady && (
+        <div class="template-section">
+          {installedAgentsCount > 0 && (
+            <div class="action-item">
+              <button
+                class="action-button"
+                onClick={updateInstalledTemplates}
+                title="Update all installed agents to their latest versions from repositories."
+              >
+                <span>Update Installed Templates ({installedAgentsCount})</span>
+              </button>
+            </div>
+          )}
+          <SearchBar
+            value={searchQuery}
+            onChange={setSearchQuery}
+            placeholder="Search agents..."
+            isScanning={metadataScan.isScanning}
+            isScanComplete={metadataScan.isComplete}
+          />
+          <TemplateMetadataProvider>
+            <div class="apm-agents-list">
+              {filteredAgents.length === 0 && (
+                <p class="empty-message">
+                  {debouncedSearchQuery ? "No agents match your search." : "No agent templates available."}
+                </p>
+              )}
+              {filteredAgents.map((agent) => (
+                <TemplateItem
+                  key={`${agent.repository}::${agent.name}`}
+                  template={agent}
+                  isInstalled={isTemplateInstalled(agent)}
+                  onInstall={() => installTemplate(agent)}
+                  onUninstall={() => uninstallTemplate(agent)}
+                />
+              ))}
+            </div>
+          </TemplateMetadataProvider>
+        </div>
+      )}
+    </>
   );
 }

--- a/src/features/panel-ui/webview/components/organisms/ProfileSection.tsx
+++ b/src/features/panel-ui/webview/components/organisms/ProfileSection.tsx
@@ -1,5 +1,4 @@
 import { useProfileData } from "../../hooks/useProfileData";
-import { CollapsibleSection } from "../molecules/CollapsibleSection";
 import { ProfileInfoTooltip } from "../atoms/ProfileInfoTooltip";
 
 /**
@@ -10,48 +9,46 @@ export function ProfileSection() {
   const { isReady, profiles, applyProfile, deleteProfile } = useProfileData();
 
   return (
-    <CollapsibleSection id="profiles" title="Profiles">
-      <>
-        {!isReady && <p class="loading">Loading profiles...</p>}
-        {isReady && profiles.length === 0 && (
-          <p class="empty-message">
-            No saved profiles yet. Save your current template configuration to quickly apply it to other workspaces.
-          </p>
-        )}
-        {isReady && profiles.length > 0 && (
-          <div class="profiles-list">
-            {profiles.map((profile) => (
-              <div key={profile.name} class="profile-item">
-                <div class="profile-info">
-                  <div class="profile-name">
-                    {profile.name}
-                    <ProfileInfoTooltip profile={profile} />
-                  </div>
-                  <div class="profile-details">
-                    {profile.templates.length} template{profile.templates.length !== 1 ? "s" : ""}
-                  </div>
+    <>
+      {!isReady && <p class="loading">Loading profiles...</p>}
+      {isReady && profiles.length === 0 && (
+        <p class="empty-message">
+          No saved profiles yet. Save your current template configuration to quickly apply it to other workspaces.
+        </p>
+      )}
+      {isReady && profiles.length > 0 && (
+        <div class="profiles-list">
+          {profiles.map((profile) => (
+            <div key={profile.name} class="profile-item">
+              <div class="profile-info">
+                <div class="profile-name">
+                  {profile.name}
+                  <ProfileInfoTooltip profile={profile} />
                 </div>
-                <div class="profile-actions-row">
-                  <button
-                    class="profile-action-button apply-button"
-                    onClick={() => applyProfile(profile)}
-                    title={`Apply profile "${profile.name}"`}
-                  >
-                    <i class="codicon codicon-rocket"></i>
-                  </button>
-                  <button
-                    class="profile-action-button delete-button"
-                    onClick={() => deleteProfile(profile)}
-                    title={`Delete profile "${profile.name}"`}
-                  >
-                    <i class="codicon codicon-trash"></i>
-                  </button>
+                <div class="profile-details">
+                  {profile.templates.length} template{profile.templates.length !== 1 ? "s" : ""}
                 </div>
               </div>
-            ))}
-          </div>
-        )}
-      </>
-    </CollapsibleSection>
+              <div class="profile-actions-row">
+                <button
+                  class="profile-action-button apply-button"
+                  onClick={() => applyProfile(profile)}
+                  title={`Apply profile "${profile.name}"`}
+                >
+                  <i class="codicon codicon-rocket"></i>
+                </button>
+                <button
+                  class="profile-action-button delete-button"
+                  onClick={() => deleteProfile(profile)}
+                  title={`Delete profile "${profile.name}"`}
+                >
+                  <i class="codicon codicon-trash"></i>
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </>
   );
 }

--- a/src/features/panel-ui/webview/components/organisms/TemplateSection.tsx
+++ b/src/features/panel-ui/webview/components/organisms/TemplateSection.tsx
@@ -3,7 +3,6 @@ import { useDebounce } from "../../hooks/useDebounce";
 import { SearchBar } from "../atoms/SearchBar";
 import { useTemplateData } from "../../hooks/useTemplateData";
 import { TemplateMetadataProvider } from "../../contexts/TemplateMetadataContext";
-import { CollapsibleSection } from "../molecules/CollapsibleSection";
 import { TypeSection } from "../molecules/TypeSection";
 import { useVSCodeAPI } from "../../hooks/useVSCodeAPI";
 import { FilterMenu } from "../atoms/FilterMenu";
@@ -258,54 +257,52 @@ export function TemplateSection() {
   };
 
   return (
-    <CollapsibleSection id="templates" title="Templates" defaultExpanded>
-      <>
-        {!isReady && <p class="loading">Loading templates...</p>}
-        {isReady && (
-          <div class="template-section">
-            {installedTemplatesCount > 0 && (
-              <div class="action-item">
-                <button
-                  class="action-button"
-                  onClick={updateInstalledTemplates}
-                  title="Update all installed templates to their latest versions from repositories."
-                >
-                  <span>Update Installed Templates ({installedTemplatesCount})</span>
-                </button>
-              </div>
-            )}
-            <div class="search-filter-row">
-              <SearchBar
-                value={searchQuery}
-                onChange={setSearchQuery}
-                isScanning={metadataScan.isScanning}
-                isScanComplete={metadataScan.isComplete}
-              />
-              <FilterMenu
-                filterMode={filterMode}
-                onFilterChange={setFilterMode}
-                typeFilters={typeFilters}
-                onTypeFiltersChange={setTypeFilters}
-                repositoryFilters={repositoryFilters}
-                onRepositoryFiltersChange={setRepositoryFilters}
-                availableTypes={availableTypes}
-                availableRepositories={availableRepositories}
-              />
-              <GroupMenu
-                groupMode={groupMode}
-                selectedFirst={selectedFirst}
-                onGroupChange={setGroupMode}
-                onSelectedFirstChange={setSelectedFirst}
-              />
+    <>
+      {!isReady && <p class="loading">Loading templates...</p>}
+      {isReady && (
+        <div class="template-section">
+          {installedTemplatesCount > 0 && (
+            <div class="action-item">
+              <button
+                class="action-button"
+                onClick={updateInstalledTemplates}
+                title="Update all installed templates to their latest versions from repositories."
+              >
+                <span>Update Installed Templates ({installedTemplatesCount})</span>
+              </button>
             </div>
-            <TemplateMetadataProvider>
-              {groupMode === "type" && renderGroupedByType()}
-              {groupMode === "repository" && renderGroupedByRepository()}
-              {groupMode === "none" && renderFlatList()}
-            </TemplateMetadataProvider>
+          )}
+          <div class="search-filter-row">
+            <SearchBar
+              value={searchQuery}
+              onChange={setSearchQuery}
+              isScanning={metadataScan.isScanning}
+              isScanComplete={metadataScan.isComplete}
+            />
+            <FilterMenu
+              filterMode={filterMode}
+              onFilterChange={setFilterMode}
+              typeFilters={typeFilters}
+              onTypeFiltersChange={setTypeFilters}
+              repositoryFilters={repositoryFilters}
+              onRepositoryFiltersChange={setRepositoryFilters}
+              availableTypes={availableTypes}
+              availableRepositories={availableRepositories}
+            />
+            <GroupMenu
+              groupMode={groupMode}
+              selectedFirst={selectedFirst}
+              onGroupChange={setGroupMode}
+              onSelectedFirstChange={setSelectedFirst}
+            />
           </div>
-        )}
-      </>
-    </CollapsibleSection>
+          <TemplateMetadataProvider>
+            {groupMode === "type" && renderGroupedByType()}
+            {groupMode === "repository" && renderGroupedByRepository()}
+            {groupMode === "none" && renderFlatList()}
+          </TemplateMetadataProvider>
+        </div>
+      )}
+    </>
   );
 }

--- a/src/features/panel-ui/webview/components/organisms/ToolsSection.tsx
+++ b/src/features/panel-ui/webview/components/organisms/ToolsSection.tsx
@@ -3,11 +3,15 @@ import { WorkflowRunnerTool } from "../molecules/WorkflowRunnerTool";
 import { useVSCodeAPI } from "../../hooks/useVSCodeAPI";
 import { useAppState } from "../../hooks/useAppState";
 
+interface ToolsSectionProps {
+  isInitialized: boolean;
+}
+
 /**
  * ToolsSection Component
- * Developer tools section (e.g., GitHub workflow runner)
+ * Developer tools section with workspace initialization and workflow runner
  */
-export function ToolsSection() {
+export function ToolsSection({ isInitialized }: ToolsSectionProps) {
   const messenger = useVSCodeAPI();
   const { workflows } = useAppState();
 
@@ -18,5 +22,23 @@ export function ToolsSection() {
     }
   }, []);
 
-  return <WorkflowRunnerTool />;
+  const initializeWorkspace = () => {
+    messenger.sendMessage({ command: "initWorkspace" });
+  };
+
+  return (
+    <>
+      {!isInitialized && (
+        <div class="actions-section">
+          <div class="action-item">
+            <button class="action-button" onClick={initializeWorkspace}>
+              <span>Initialize Project</span>
+            </button>
+            <p class="button-description">Set up Nexkit templates and configuration for your workspace</p>
+          </div>
+        </div>
+      )}
+      <WorkflowRunnerTool />
+    </>
+  );
 }

--- a/src/features/panel-ui/webview/components/organisms/ToolsSection.tsx
+++ b/src/features/panel-ui/webview/components/organisms/ToolsSection.tsx
@@ -1,12 +1,11 @@
 import { useEffect } from "preact/hooks";
-import { CollapsibleSection } from "../molecules/CollapsibleSection";
 import { WorkflowRunnerTool } from "../molecules/WorkflowRunnerTool";
 import { useVSCodeAPI } from "../../hooks/useVSCodeAPI";
 import { useAppState } from "../../hooks/useAppState";
 
 /**
  * ToolsSection Component
- * Collapsible section providing developer tools (e.g., GitHub workflow runner)
+ * Developer tools section (e.g., GitHub workflow runner)
  */
 export function ToolsSection() {
   const messenger = useVSCodeAPI();
@@ -19,9 +18,5 @@ export function ToolsSection() {
     }
   }, []);
 
-  return (
-    <CollapsibleSection id="tools" title="Tools">
-      <WorkflowRunnerTool />
-    </CollapsibleSection>
-  );
+  return <WorkflowRunnerTool />;
 }

--- a/src/features/panel-ui/webview/components/organisms/ToolsSection.tsx
+++ b/src/features/panel-ui/webview/components/organisms/ToolsSection.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "preact/hooks";
 import { WorkflowRunnerTool } from "../molecules/WorkflowRunnerTool";
+import { CollapsibleSection } from "../molecules/CollapsibleSection";
 import { useVSCodeAPI } from "../../hooks/useVSCodeAPI";
 import { useAppState } from "../../hooks/useAppState";
 
@@ -38,7 +39,9 @@ export function ToolsSection({ isInitialized }: ToolsSectionProps) {
           </div>
         </div>
       )}
-      <WorkflowRunnerTool />
+      <CollapsibleSection id="tools-workflow-runner" title="GitHub Workflow Runner">
+        <WorkflowRunnerTool />
+      </CollapsibleSection>
     </>
   );
 }

--- a/src/features/panel-ui/webview/hooks/useActiveTab.ts
+++ b/src/features/panel-ui/webview/hooks/useActiveTab.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect } from "preact/hooks";
+import { useWebviewPersistentState } from "./useWebviewPersistentState";
+
+/**
+ * Hook to manage the active tab selection with persistence across webview reloads.
+ *
+ * @param availableTabIds - The list of tab IDs currently visible (mode-dependent)
+ * @returns Tuple of [activeTabId, setActiveTabId]
+ */
+export function useActiveTab(availableTabIds: string[]): [string, (tabId: string) => void] {
+  const { getWebviewState, setWebviewState } = useWebviewPersistentState();
+
+  const [activeTab, setActiveTab] = useState<string>(() => {
+    const stored = getWebviewState().activeTab;
+    // If the stored tab is still available, use it; otherwise fall back to the first tab
+    if (stored && availableTabIds.includes(stored)) {
+      return stored;
+    }
+    return availableTabIds[0] ?? "";
+  });
+
+  // If available tabs change (e.g. mode switch) and current tab is no longer valid, reset
+  useEffect(() => {
+    if (availableTabIds.length > 0 && !availableTabIds.includes(activeTab)) {
+      setActiveTab(availableTabIds[0]);
+    }
+  }, [availableTabIds, activeTab]);
+
+  // Persist active tab to VS Code webview state
+  useEffect(() => {
+    const currentState = getWebviewState();
+    currentState.activeTab = activeTab;
+    setWebviewState(currentState);
+  }, [activeTab]);
+
+  return [activeTab, setActiveTab];
+}

--- a/src/features/panel-ui/webview/hooks/useWebviewPersistentState.ts
+++ b/src/features/panel-ui/webview/hooks/useWebviewPersistentState.ts
@@ -9,6 +9,7 @@ const DEFAULT_STATE: WebviewPersistentState = {
   selectedFirst: true,
   typeFilters: [],
   repositoryFilters: [],
+  activeTab: undefined,
 };
 
 /**

--- a/src/features/panel-ui/webview/hooks/useWebviewPersistentState.ts
+++ b/src/features/panel-ui/webview/hooks/useWebviewPersistentState.ts
@@ -10,6 +10,7 @@ const DEFAULT_STATE: WebviewPersistentState = {
   typeFilters: [],
   repositoryFilters: [],
   activeTab: undefined,
+  lastSeenProfileCount: undefined,
 };
 
 /**

--- a/src/features/panel-ui/webview/styles.css
+++ b/src/features/panel-ui/webview/styles.css
@@ -137,6 +137,22 @@ body {
   color: var(--vscode-focusBorder);
 }
 
+.tab-icon-wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.tab-badge {
+  position: absolute;
+  top: -2px;
+  right: -4px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background-color: var(--vscode-focusBorder);
+  pointer-events: none;
+}
+
 .tab-content {
   min-height: 0;
 }

--- a/src/features/panel-ui/webview/styles.css
+++ b/src/features/panel-ui/webview/styles.css
@@ -98,6 +98,49 @@ body {
   border-top: none;
 }
 
+/* ============================================ */
+/* Tab Bar                                      */
+/* ============================================ */
+
+.tab-bar {
+  display: flex;
+  gap: 2px;
+  border-bottom: 1px solid var(--vscode-panel-border);
+  margin-bottom: 12px;
+  padding: 0 4px;
+}
+
+.tab-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  padding: 8px 0;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--vscode-foreground);
+  cursor: pointer;
+  opacity: 0.6;
+  transition: opacity 0.15s ease, border-color 0.15s ease;
+  font-size: 16px;
+}
+
+.tab-button:hover {
+  opacity: 1;
+  background-color: var(--vscode-list-hoverBackground);
+}
+
+.tab-button.active {
+  opacity: 1;
+  border-bottom-color: var(--vscode-focusBorder);
+  color: var(--vscode-focusBorder);
+}
+
+.tab-content {
+  min-height: 0;
+}
+
 .section .section-header {
   cursor: pointer;
   user-select: none;

--- a/src/features/panel-ui/webview/types/index.ts
+++ b/src/features/panel-ui/webview/types/index.ts
@@ -27,4 +27,5 @@ export interface WebviewPersistentState {
   selectedFirst: boolean;
   typeFilters: string[];
   repositoryFilters: string[];
+  activeTab?: string;
 }

--- a/src/features/panel-ui/webview/types/index.ts
+++ b/src/features/panel-ui/webview/types/index.ts
@@ -28,4 +28,5 @@ export interface WebviewPersistentState {
   typeFilters: string[];
   repositoryFilters: string[];
   activeTab?: string;
+  lastSeenProfileCount?: number;
 }

--- a/test/suite/githubWorkflowRunnerService.test.ts
+++ b/test/suite/githubWorkflowRunnerService.test.ts
@@ -72,7 +72,7 @@ suite("Unit: GitHubWorkflowRunnerService", () => {
     const mockUri = vscode.Uri.file("/mock/workspace");
     sandbox.stub(vscode.workspace, "workspaceFolders").value([{ uri: mockUri, name: "mock", index: 0 }]);
     sandbox.stub(service, "isDockerInstalled").returns(true);
-    sandbox.stub(service, "isDockerRunning").returns(true);
+    sandbox.stub(service, "isDockerRunning").resolves(true);
     sandbox.stub(service, "findActPath").returns("/usr/bin/act");
 
     const mockTerminal = {
@@ -106,7 +106,7 @@ suite("Unit: GitHubWorkflowRunnerService", () => {
     const mockUri = vscode.Uri.file("/mock/workspace");
     sandbox.stub(vscode.workspace, "workspaceFolders").value([{ uri: mockUri, name: "mock", index: 0 }]);
     sandbox.stub(service, "isDockerInstalled").returns(true);
-    sandbox.stub(service, "isDockerRunning").returns(true);
+    sandbox.stub(service, "isDockerRunning").resolves(true);
     sandbox.stub(service, "findActPath").returns("/usr/bin/act");
 
     const mockTerminal = {
@@ -131,7 +131,7 @@ suite("Unit: GitHubWorkflowRunnerService", () => {
     const mockUri = vscode.Uri.file("/mock/workspace");
     sandbox.stub(vscode.workspace, "workspaceFolders").value([{ uri: mockUri, name: "mock", index: 0 }]);
     sandbox.stub(service, "isDockerInstalled").returns(true);
-    sandbox.stub(service, "isDockerRunning").returns(true);
+    sandbox.stub(service, "isDockerRunning").resolves(true);
     sandbox.stub(service, "findActPath").returns("/usr/bin/act");
 
     const mockTerminal = {
@@ -220,7 +220,7 @@ suite("Unit: GitHubWorkflowRunnerService", () => {
     sandbox.stub(vscode.workspace, "workspaceFolders").value([{ uri: mockUri, name: "mock", index: 0 }]);
     sandbox.stub(service, "findActPath").returns(undefined);
     sandbox.stub(service, "isDockerInstalled").returns(true);
-    sandbox.stub(service, "isDockerRunning").returns(true);
+    sandbox.stub(service, "isDockerRunning").resolves(true);
 
     // User dismisses the dialog
     const warningStub = sandbox.stub(vscode.window, "showWarningMessage").resolves(undefined);
@@ -295,7 +295,7 @@ suite("Unit: GitHubWorkflowRunnerService", () => {
     const mockUri = vscode.Uri.file("/mock/workspace");
     sandbox.stub(vscode.workspace, "workspaceFolders").value([{ uri: mockUri, name: "mock", index: 0 }]);
     sandbox.stub(service, "isDockerInstalled").returns(true);
-    sandbox.stub(service, "isDockerRunning").returns(false);
+    sandbox.stub(service, "isDockerRunning").resolves(false);
 
     const errorStub = sandbox.stub(vscode.window, "showErrorMessage").resolves(undefined);
     const createTerminalStub = sandbox.stub(vscode.window, "createTerminal");
@@ -316,7 +316,7 @@ suite("Unit: GitHubWorkflowRunnerService", () => {
     const mockUri = vscode.Uri.file("/mock/workspace");
     sandbox.stub(vscode.workspace, "workspaceFolders").value([{ uri: mockUri, name: "mock", index: 0 }]);
     sandbox.stub(service, "isDockerInstalled").returns(true);
-    sandbox.stub(service, "isDockerRunning").returns(true);
+    sandbox.stub(service, "isDockerRunning").resolves(true);
     sandbox.stub(service, "findActPath").returns("/usr/bin/act");
 
     const mockTerminal = {

--- a/test/suite/githubWorkflowRunnerService.test.ts
+++ b/test/suite/githubWorkflowRunnerService.test.ts
@@ -269,10 +269,7 @@ suite("Unit: GitHubWorkflowRunnerService", () => {
     });
 
     assert.ok(errorStub.calledOnce, "Should show error message");
-    assert.ok(
-      errorStub.firstCall.args[0].includes("Docker is required"),
-      "Error message should mention Docker is required"
-    );
+    assert.ok(errorStub.firstCall.args[0].includes("Docker is required"), "Error message should mention Docker is required");
     assert.ok(createTerminalStub.notCalled, "Should not create terminal");
   });
 
@@ -311,10 +308,7 @@ suite("Unit: GitHubWorkflowRunnerService", () => {
     });
 
     assert.ok(errorStub.calledOnce, "Should show error message");
-    assert.ok(
-      errorStub.firstCall.args[0].includes("not running"),
-      "Error message should mention Docker is not running"
-    );
+    assert.ok(errorStub.firstCall.args[0].includes("not running"), "Error message should mention Docker is not running");
     assert.ok(createTerminalStub.notCalled, "Should not create terminal");
   });
 

--- a/test/suite/githubWorkflowRunnerService.test.ts
+++ b/test/suite/githubWorkflowRunnerService.test.ts
@@ -71,6 +71,8 @@ suite("Unit: GitHubWorkflowRunnerService", () => {
   test("Should create terminal and send act command for runWorkflow", async () => {
     const mockUri = vscode.Uri.file("/mock/workspace");
     sandbox.stub(vscode.workspace, "workspaceFolders").value([{ uri: mockUri, name: "mock", index: 0 }]);
+    sandbox.stub(service, "isDockerInstalled").returns(true);
+    sandbox.stub(service, "isDockerRunning").returns(true);
     sandbox.stub(service, "findActPath").returns("/usr/bin/act");
 
     const mockTerminal = {
@@ -103,6 +105,8 @@ suite("Unit: GitHubWorkflowRunnerService", () => {
   test("Should not include --job flag when job is not specified", async () => {
     const mockUri = vscode.Uri.file("/mock/workspace");
     sandbox.stub(vscode.workspace, "workspaceFolders").value([{ uri: mockUri, name: "mock", index: 0 }]);
+    sandbox.stub(service, "isDockerInstalled").returns(true);
+    sandbox.stub(service, "isDockerRunning").returns(true);
     sandbox.stub(service, "findActPath").returns("/usr/bin/act");
 
     const mockTerminal = {
@@ -126,6 +130,8 @@ suite("Unit: GitHubWorkflowRunnerService", () => {
   test("Should use --list flag when list is true", async () => {
     const mockUri = vscode.Uri.file("/mock/workspace");
     sandbox.stub(vscode.workspace, "workspaceFolders").value([{ uri: mockUri, name: "mock", index: 0 }]);
+    sandbox.stub(service, "isDockerInstalled").returns(true);
+    sandbox.stub(service, "isDockerRunning").returns(true);
     sandbox.stub(service, "findActPath").returns("/usr/bin/act");
 
     const mockTerminal = {
@@ -213,6 +219,8 @@ suite("Unit: GitHubWorkflowRunnerService", () => {
     const mockUri = vscode.Uri.file("/mock/workspace");
     sandbox.stub(vscode.workspace, "workspaceFolders").value([{ uri: mockUri, name: "mock", index: 0 }]);
     sandbox.stub(service, "findActPath").returns(undefined);
+    sandbox.stub(service, "isDockerInstalled").returns(true);
+    sandbox.stub(service, "isDockerRunning").returns(true);
 
     // User dismisses the dialog
     const warningStub = sandbox.stub(vscode.window, "showWarningMessage").resolves(undefined);
@@ -231,5 +239,106 @@ suite("Unit: GitHubWorkflowRunnerService", () => {
       createTerminalStub.notCalled || warningStub.called || errorStub.called,
       "Should prompt user about missing act instead of running"
     );
+  });
+
+  // ============================================================================
+  // Docker availability tests
+  // ============================================================================
+
+  test("Should have isDockerInstalled method", () => {
+    assert.strictEqual(typeof service.isDockerInstalled, "function");
+  });
+
+  test("Should have isDockerRunning method", () => {
+    assert.strictEqual(typeof service.isDockerRunning, "function");
+  });
+
+  test("Should show error when Docker is not installed", async () => {
+    const mockUri = vscode.Uri.file("/mock/workspace");
+    sandbox.stub(vscode.workspace, "workspaceFolders").value([{ uri: mockUri, name: "mock", index: 0 }]);
+    sandbox.stub(service, "isDockerInstalled").returns(false);
+
+    const errorStub = sandbox.stub(vscode.window, "showErrorMessage").resolves(undefined);
+    const createTerminalStub = sandbox.stub(vscode.window, "createTerminal");
+
+    await service.runWorkflow({
+      workflowFile: ".github/workflows/ci.yml",
+      event: "push",
+      dryRun: false,
+      list: false,
+    });
+
+    assert.ok(errorStub.calledOnce, "Should show error message");
+    assert.ok(
+      errorStub.firstCall.args[0].includes("Docker is required"),
+      "Error message should mention Docker is required"
+    );
+    assert.ok(createTerminalStub.notCalled, "Should not create terminal");
+  });
+
+  test("Should open Docker install page when user clicks action", async () => {
+    const mockUri = vscode.Uri.file("/mock/workspace");
+    sandbox.stub(vscode.workspace, "workspaceFolders").value([{ uri: mockUri, name: "mock", index: 0 }]);
+    sandbox.stub(service, "isDockerInstalled").returns(false);
+
+    sandbox.stub(vscode.window, "showErrorMessage").resolves("Open Docker Install Page" as any);
+    const openExternalStub = sandbox.stub(vscode.env, "openExternal");
+
+    await service.runWorkflow({
+      workflowFile: ".github/workflows/ci.yml",
+      event: "push",
+      dryRun: false,
+      list: false,
+    });
+
+    assert.ok(openExternalStub.calledOnce, "Should open external URL");
+  });
+
+  test("Should show error when Docker is installed but not running", async () => {
+    const mockUri = vscode.Uri.file("/mock/workspace");
+    sandbox.stub(vscode.workspace, "workspaceFolders").value([{ uri: mockUri, name: "mock", index: 0 }]);
+    sandbox.stub(service, "isDockerInstalled").returns(true);
+    sandbox.stub(service, "isDockerRunning").returns(false);
+
+    const errorStub = sandbox.stub(vscode.window, "showErrorMessage").resolves(undefined);
+    const createTerminalStub = sandbox.stub(vscode.window, "createTerminal");
+
+    await service.runWorkflow({
+      workflowFile: ".github/workflows/ci.yml",
+      event: "push",
+      dryRun: false,
+      list: false,
+    });
+
+    assert.ok(errorStub.calledOnce, "Should show error message");
+    assert.ok(
+      errorStub.firstCall.args[0].includes("not running"),
+      "Error message should mention Docker is not running"
+    );
+    assert.ok(createTerminalStub.notCalled, "Should not create terminal");
+  });
+
+  test("Should proceed when Docker is installed and running", async () => {
+    const mockUri = vscode.Uri.file("/mock/workspace");
+    sandbox.stub(vscode.workspace, "workspaceFolders").value([{ uri: mockUri, name: "mock", index: 0 }]);
+    sandbox.stub(service, "isDockerInstalled").returns(true);
+    sandbox.stub(service, "isDockerRunning").returns(true);
+    sandbox.stub(service, "findActPath").returns("/usr/bin/act");
+
+    const mockTerminal = {
+      show: sandbox.stub(),
+      sendText: sandbox.stub(),
+    };
+    sandbox.stub(vscode.window, "createTerminal").returns(mockTerminal as any);
+
+    await service.runWorkflow({
+      workflowFile: ".github/workflows/ci.yml",
+      event: "push",
+      dryRun: false,
+      list: false,
+    });
+
+    assert.ok(mockTerminal.show.calledOnce, "Should create and show terminal");
+    assert.ok(mockTerminal.sendText.calledOnce, "Should send act command");
   });
 });


### PR DESCRIPTION
## Summary

Converts the Nexkit sidebar panel from stacked collapsible sections to a horizontal icon tab bar. Each section (Templates, Tools, Profiles, Project) is now a dedicated tab with a codicon icon. Tabs are mode-aware and the active selection persists across webview reloads. Notification badges alert users to actionable items.

## Related Work Items

N/A

## Changes

- **TabBar component**: New `TabBar` molecule renders a horizontal icon tab bar with `role="tablist"` accessibility attributes and support for notification badge dots
- **useActiveTab hook**: New hook manages active tab state with persistence via VS Code webview state, handling mode switches gracefully
- **App.tsx**: Replaced stacked `CollapsibleSection` rendering with tab-based layout. Computes badge state for Tools (needs initialization) and Profiles (new profile saved since last visit)
- **ToolsSection**: Now receives `isInitialized` prop and renders the "Initialize Project" button directly inside the Tools tab instead of a separate `ActionsSection`
- **ProfileSection, TemplateSection, ApmTemplateSection, ApmConnectionSection**: Removed `CollapsibleSection` wrappers — content renders directly inside the tab panel
- **WebviewPersistentState**: Added `activeTab` and `lastSeenProfileCount` for tab and badge persistence
- **styles.css**: Added tab bar styles (`.tab-bar`, `.tab-button`, `.tab-badge`, `.tab-icon-wrapper`) with VS Code theme variable integration

**Tab configuration by mode:**
| Tab | Icon | Developers | APM |
|-----|------|:---:|:---:|
| Templates | `codicon-file-code` | ✓ | ✓ |
| Tools | `codicon-tools` | ✓ | |
| Profiles | `codicon-account` | ✓ | |
| Project | `codicon-azure-devops` | | ✓ |

## How to Test

1. Press `F5` to launch the Extension Development Host
2. Open a workspace and verify the tab bar appears with the correct icons for the active mode
3. Switch tabs — verify content switches and active tab has a blue underline
4. Close and reopen the panel — verify the last active tab is restored
5. In an uninitialized workspace, verify a blue badge dot appears on the Tools tab
6. Save a new profile, switch away from the Profiles tab — verify a blue badge appears, then disappears when returning to the Profiles tab
7. Switch between Developer and APM modes — verify the correct tabs are shown

## Notes

- `ActionsSection` is no longer used in Developers mode (init button moved to Tools tab). The component still exists for potential future use but is no longer imported in `App.tsx`.
- The `CollapsibleSection` molecule is retained for potential reuse elsewhere but is no longer used by the main section organisms.