### PR TITLE
fix(panel-ui): add init-banner layout styles for action row

### DIFF
--- a/src/features/panel-ui/webview/styles.css
+++ b/src/features/panel-ui/webview/styles.css
@@ -42,6 +42,18 @@ body {
   gap: 6px;
 }
 
+.init-banner {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.init-banner .action-button {
+  flex: 0 0 auto;
+}
+
 .action-button {
   padding: 8px;
   font-size: 0.9em;


### PR DESCRIPTION
- Add flex row layout for .init-banner container with stretch alignment
- Style .init-banner action buttons to prevent flex shrinking

Estimated review time: 1 minute