### PR TITLE
Fix Convert to Markdown panel and update to v3.11.2-beta.1

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -61,6 +61,8 @@ function copyStaticFiles() {
       if (fs.existsSync(source)) {
         fs.copyFileSync(source, dest);
         console.log(`[copy] ${file} -> ${path.relative(__dirname, config.outputDir)}/${file}`);
+      } else {
+        console.warn(`[copy] WARNING: source file not found, skipped: ${path.relative(__dirname, source)}`);
       }
     });
 

--- a/src/features/convert-to-markdown/convertToMarkdownPanelService.ts
+++ b/src/features/convert-to-markdown/convertToMarkdownPanelService.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import * as vscode from "vscode";
 import { IMarkitdownConversionService } from "./markitdownConversionService";
 import { HostToWebviewMessage, WebviewToHostMessage } from "./messages";
+import { LoggingService } from "../../shared/services/loggingService";
 
 /**
  * Manages the standalone Convert to Markdown webview panel
@@ -137,7 +138,8 @@ export class ConvertToMarkdownPanelService implements vscode.Disposable {
     let html: string;
     try {
       html = fs.readFileSync(htmlPath.fsPath, "utf8");
-    } catch {
+    } catch (error) {
+      LoggingService.getInstance().error(`Failed to read Convert to Markdown webview HTML at ${htmlPath.fsPath}`, error);
       void vscode.window.showErrorMessage(
         "Unable to load the Convert to Markdown webview. Please rebuild the extension (npm run compile) and try again."
       );

--- a/src/features/convert-to-markdown/webview/index.html
+++ b/src/features/convert-to-markdown/webview/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src {{cspSource}} 'unsafe-inline'; script-src 'nonce-{{nonce}}';">
+    <title>Convert to Markdown</title>
+</head>
+<body>
+    <!-- Preact app will be rendered here -->
+    <div id="root"></div>
+    <script nonce="{{nonce}}" src="{{scriptUri}}"></script>
+</body>
+</html>


### PR DESCRIPTION
Enhance the Convert to Markdown panel by fixing RTF to Markdown conversion and adding error logging for webview HTML loading. Include a missing HTML file for the webview and update the version to 3.11.2-beta.1. Closes issue #193.